### PR TITLE
Enabled autoload of PHPExcel library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "os/php-excel": "2.1"
   },
   "autoload": {
-      "psr-0": { "OS\\ExcelBundle": "" }
+      "psr-0": { "OS\\ExcelBundle": "" },
+      "files": ["vendor/os/php-excel/PHPExcel/PHPExcel.php"]
   },
   "minimum-stability": "dev",
   "target-dir": "OS/ExcelBundle"


### PR DESCRIPTION
This will autoload the PHPExcel library and make the installation cleaner.
No more editing of the app/autoload.php file
